### PR TITLE
First file in archive should be named mimetype, not metadata

### DIFF
--- a/lib/src/epub_writer.dart
+++ b/lib/src/epub_writer.dart
@@ -17,7 +17,7 @@ class EpubWriter {
 
     // Add simple metadata
     arch.addFile(ArchiveFile.noCompress(
-        'metadata', 20, convert.utf8.encode('application/epub+zip')));
+        'mimetype', 20, convert.utf8.encode('application/epub+zip')));
 
     // Add Container file
     arch.addFile(ArchiveFile('META-INF/container.xml', _container_file.length,


### PR DESCRIPTION
Validation fails in http://validator.idpf.org/ and also OSX Books won't open generated epubs without this change.